### PR TITLE
feat: implement user sign-in UI and error messages handling (no validation yet)

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AHON_TRACK.App"
              xmlns:local="using:AHON_TRACK"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.DataTemplates>

--- a/ViewModels/LoginViewModel.cs
+++ b/ViewModels/LoginViewModel.cs
@@ -1,7 +1,50 @@
-﻿namespace AHON_TRACK.ViewModels
+﻿using CommunityToolkit.Mvvm.Input;
+using ShadUI.Dialogs;
+using System.ComponentModel.DataAnnotations;
+
+namespace AHON_TRACK.ViewModels
 {
     public partial class LoginViewModel : ViewModelBase
     {
-        public string Greeting { get; } = "Welcome to AHON Track! Login Page";
+        private string _username = string.Empty;
+
+        [Required(ErrorMessage = "Email is required")]
+        public string Username 
+        {
+            get => _username;
+            set => SetProperty(ref _username, value, true);
+        }
+
+        private string _password = string.Empty;
+
+        [Required(ErrorMessage = "Password is required")]
+        [MinLength(8, ErrorMessage = "Password must be at least 8 characters long")]
+        public string Password
+        {
+            get => _password;
+            set => SetProperty(ref _password, value, true);
+        }
+
+        private bool CanSignIn()
+        {
+            return !HasErrors;
+        }
+
+        public void Initialize()
+        {
+            Username = string.Empty;
+            Password = string.Empty;
+
+            ClearAllErrors();
+        }
+
+        [RelayCommand(CanExecute = nameof(CanSignIn))]
+        private void SignIn()
+        {
+            ClearAllErrors();
+            ValidateAllProperties();
+
+            if (HasErrors) return;
+        }
     }
 }

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -1,8 +1,99 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using CommunityToolkit.Mvvm.ComponentModel;
 
-namespace AHON_TRACK.ViewModels
+namespace AHON_TRACK.ViewModels;
+
+public abstract class ViewModelBase : ObservableObject, INotifyDataErrorInfo
 {
-    public class ViewModelBase : ObservableObject
+    private readonly Dictionary<string, List<string>> _errors = new();
+
+    public bool HasErrors => _errors.Count != 0;
+
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+    public IEnumerable GetErrors(string? propertyName)
     {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return Array.Empty<string>();
+        }
+
+        return _errors.TryGetValue(propertyName, out var errors)
+            ? errors
+            : Array.Empty<string>();
+    }
+
+    protected void SetProperty<T>(ref T field, T value, bool validate = false,
+        [CallerMemberName] string propertyName = null!)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        if (validate) ValidateProperty(value, propertyName);
+    }
+
+    protected void ValidateProperty<T>(T value, string propertyName)
+    {
+        ClearErrors(propertyName);
+
+        var validationContext = new ValidationContext(this)
+        {
+            MemberName = propertyName
+        };
+        var validationResults = new List<ValidationResult>();
+
+        if (Validator.TryValidateProperty(value, validationContext, validationResults)) return;
+
+        foreach (var validationResult in validationResults)
+            AddError(propertyName, validationResult.ErrorMessage ?? string.Empty);
+    }
+
+    protected void AddError(string propertyName, string error)
+    {
+        if (!_errors.ContainsKey(propertyName))
+        {
+            _errors[propertyName] = new List<string>();
+        }
+
+        if (_errors[propertyName].Contains(error)) return;
+
+        _errors[propertyName].Add(error);
+        OnErrorsChanged(propertyName);
+    }
+
+    protected void ClearErrors(string propertyName)
+    {
+        if (_errors.Remove(propertyName)) OnErrorsChanged(propertyName);
+    }
+
+    protected void ClearAllErrors()
+    {
+        var properties = _errors.Keys.ToList();
+        _errors.Clear();
+        foreach (var property in properties) OnErrorsChanged(property);
+    }
+
+    private void OnErrorsChanged(string propertyName)
+    {
+        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+    }
+
+    protected void ValidateAllProperties()
+    {
+        var properties = GetType().GetProperties()
+            .Where(prop => prop.GetCustomAttributes(typeof(ValidationAttribute), true).Length != 0);
+
+        foreach (var property in properties)
+        {
+            var value = property.GetValue(this);
+            ValidateProperty(value, property.Name);
+        }
     }
 }

--- a/Views/LoginView.axaml
+++ b/Views/LoginView.axaml
@@ -23,6 +23,8 @@
 
 	<Window.Resources>
 		<SolidColorBrush x:Key="Foreground" Color="#09090B"/>
+		<SolidColorBrush x:Key="Background" Color="#FFFFFF"/>
+		<!-- <SolidColorBrush x:Key="CardBackgroundColor" Color="#FFF7F7F7"/> -->
 	</Window.Resources>
 
 	<Design.DataContext>
@@ -33,7 +35,7 @@
 
 
 	<Grid>
-		<StackPanel HorizontalAlignment="Left" Margin="95,110,10,10">
+		<StackPanel HorizontalAlignment="Left" Margin="45,110,10,10">
 			<TextBlock
 				Text="The future of"
 				Foreground="{StaticResource Foreground}"
@@ -88,7 +90,7 @@
 			/>
 
 			<Button
-				Classes="Secondary"
+				Classes="Primary"
 				Content="About Us"
 				HorizontalAlignment="Left"
 				Margin="50,60" 
@@ -99,7 +101,38 @@
 		</StackPanel>
 
 		<StackPanel HorizontalAlignment="Right">
-			
+			<controls:Card HorizontalAlignment="Right" Width="445" Height="580" Margin="30,50" >
+				<controls:Card.Header>
+					<StackPanel Spacing="5">
+						<controls:CardTitle FontFamily="Inter" FontSize="35" FontWeight="Bold">Sign In</controls:CardTitle>
+						<controls:CardDescription FontFamily="Inter" FontSize="18">Enter your credentials</controls:CardDescription>
+					</StackPanel>
+				</controls:Card.Header>
+				<StackPanel Spacing="30">
+					<TextBox
+						Classes="Clearable"
+						extensions:ControlAssist.Label="Username"
+						extensions:ControlAssist.Height="40"
+						Watermark="Username"
+						FontSize="17"
+						Text="{Binding Username, Mode=TwoWay}"
+					/>
+					<TextBox
+						Classes="PasswordReveal"
+						extensions:ControlAssist.Label="Password"
+						extensions:ControlAssist.Height="40"
+						PasswordChar="•"
+						Watermark="Enter your password"
+						FontSize="17"
+						Text="{Binding Password, Mode=TwoWay}"
+					/>
+				</StackPanel>
+				<controls:Card.Footer>
+					<Button Classes="Primary" FontSize="20" Padding="0,0" Margin="0,30" Height="38" Width="140" HorizontalAlignment="Right" Command="{Binding SignInCommand}">
+						Sign In
+					</Button>
+				</controls:Card.Footer>
+			</controls:Card>
 		</StackPanel>
 	</Grid>
 


### PR DESCRIPTION
This pull request introduces several components for the user authentication interface and related UI behaviors. The following updates were made:

### What's Added
- Admin and user sign-in form and card UI components
- Initial error messages for empty username and password fields (validation not yet included)
- Theme temporarily set to "Light" for consistency across new views
- Helper methods scaffolded for future use in ViewModels

### Notes
- Input validation logic is not yet implemented; this PR focuses on UI and UX groundwork
- ViewModel helper methods are placeholders and will be fleshed out in upcoming commits

### Next Steps
- Add full validation logic for sign-in form
- Toast messages for success and error
- Add `IsBusy` animation for Sign In

---